### PR TITLE
Support 8.2 Root

### DIFF
--- a/CASCEdit/CASContainer.cs
+++ b/CASCEdit/CASContainer.cs
@@ -193,7 +193,7 @@ namespace CASCEdit
             }
         }
 
-        public static void OpenRoot(LocaleFlags locale, uint minimumid = 0)
+        public static void OpenRoot(LocaleFlags locale, uint minimumid = 0, bool onlineListfile = false)
         {
             Logger.LogInformation("Loading Root...");
 
@@ -208,7 +208,7 @@ namespace CASCEdit
             if (idxInfo != null)
             {
                 var path = Path.Combine(BasePath, "Data", "data", string.Format("data.{0:D3}", idxInfo.Archive));
-                RootHandler = new RootHandler(DataHandler.Read(path, idxInfo), locale, minimumid);
+                RootHandler = new RootHandler(DataHandler.Read(path, idxInfo), locale, minimumid, onlineListfile);
             }
             else
             {
@@ -223,7 +223,7 @@ namespace CASCEdit
                         Logger.LogCritical($"Unable to download Root {key}.");
                 }
 
-                RootHandler = new RootHandler(DataHandler.ReadDirect(path), locale, minimumid);
+                RootHandler = new RootHandler(DataHandler.ReadDirect(path), locale, minimumid, onlineListfile);
             }
         }
 

--- a/CASCEdit/Handlers/ArchiveGroupIndex.cs
+++ b/CASCEdit/Handlers/ArchiveGroupIndex.cs
@@ -72,12 +72,11 @@ namespace CASCEdit.Handlers
 
                 Footer = new IndexFooter()
                 {
-                    IndexBlockHash = br.ReadBytes(8),
                     TOCHash = br.ReadBytes(8),
                     Version = br.ReadByte(),
                     _11 = br.ReadByte(),
                     _12 = br.ReadByte(),
-                    _13 = br.ReadByte(),
+                    BlockSizeKb = br.ReadByte(),
                     Offset = br.ReadByte(),
                     Size = br.ReadByte(),
                     KeySize = br.ReadByte(),
@@ -155,7 +154,7 @@ namespace CASCEdit.Handlers
                 bw.Write(Footer.Version);
                 bw.Write(Footer._11);
                 bw.Write(Footer._12);
-                bw.Write(Footer._13);
+                bw.Write(Footer.BlockSizeKb);
                 bw.Write(Footer.Offset);
                 bw.Write(Footer.Size);
                 bw.Write(Footer.KeySize);

--- a/CASCEdit/Handlers/ArchiveIndex.cs
+++ b/CASCEdit/Handlers/ArchiveIndex.cs
@@ -16,7 +16,7 @@ namespace CASCEdit.Handlers
 		public IndexFooter Footer = new IndexFooter();
 
 		public readonly string BaseFile;
-		const int CHUNK_SIZE = 4096;
+		const int CHUNK_SIZE = 0x1000;
 
 		public ArchiveIndexHandler(string path = "")
 		{
@@ -60,7 +60,7 @@ namespace CASCEdit.Handlers
 				br.BaseStream.Position += blockcount * 16;
 
 				//Block hashes - lower_md5 all blocks except last
-				br.BaseStream.Position += (blockcount - 1) * 8;
+				br.BaseStream.Position += blockcount * 8;
 
 				//Footer
 				Footer = new IndexFooter()

--- a/CASCEdit/Handlers/RootHandler.cs
+++ b/CASCEdit/Handlers/RootHandler.cs
@@ -120,7 +120,8 @@ namespace CASCEdit.Handlers
 						.SelectMany(chunk => chunk.Entries) // Flatten the array to get all entries within all matching chunks
 						.Where(e => e.NameHash == namehash);
 						
-			if (entries.Count() == 0) { // New file, we need to create an entry for it
+			if (entries.Count() == 0)
+            { // New file, we need to create an entry for it
 				var cached = cache.Entries.FirstOrDefault(x => x.Path == path);
 				var fileDataId = Math.Max(maxId + 1, minimumId);
 
@@ -138,8 +139,11 @@ namespace CASCEdit.Handlers
 
 				GlobalRoot.Entries.Add(entry); // Insert into the Global Root
 				maxId = Math.Max(entry.FileDataId, maxId); // Update the max id
-			} else { // Existing file, we just have to update the data hash
-				foreach (var entry in entries) {
+			}
+            else
+            { // Existing file, we just have to update the data hash
+				foreach (var entry in entries)
+                {
 					entry.CEKey = file.CEKey;
 					entry.Path = path;
 

--- a/CASCEdit/Structs/IndexStructs.cs
+++ b/CASCEdit/Structs/IndexStructs.cs
@@ -26,12 +26,11 @@ namespace CASCEdit.Structs
 
     public class IndexFooter
     {
-        public byte[] IndexBlockHash; // ChecksumSize
         public byte[] TOCHash; // ChecksumSize
         public byte Version = 1;
         public byte _11 = 0;
         public byte _12 = 0;
-        public byte _13 = 4;
+        public byte BlockSizeKb = 4;
         public byte Offset = 4;
         public byte Size = 4;
         public byte KeySize = 16;

--- a/CASCEdit/Structs/RootStructs.cs
+++ b/CASCEdit/Structs/RootStructs.cs
@@ -41,7 +41,7 @@ namespace CASCEdit.Structs
         F00000008 = 0x8, // added in 7.2.0.23436
         F00000010 = 0x10, // added in 7.2.0.23436
         LowViolence = 0x80, // many models have this flag
-        F10000000 = 0x10000000,
+        NoNames = 0x10000000,
         F20000000 = 0x20000000, // added in 21737
         Bundle = 0x40000000,
         NoCompression = 0x80000000 // sounds have this flag

--- a/CASCHost/AppSettings.cs
+++ b/CASCHost/AppSettings.cs
@@ -13,7 +13,8 @@ namespace CASCHost
 	public class AppSettings
 	{
 		public uint MinimumFileDataId { get; set; } // the minimum file id for new files
-		public bool BNetAppSupport { get; set; } = false; // create install and download files?
+        public bool OnlineListFile { get; set; } = false; // fetchs from WoW.Tools the lastest listfile 
+        public bool BNetAppSupport { get; set; } = false; // create install and download files?
 		public bool StaticMode { get; set; } = false; // Build CDN file struct
         public string RebuildPassword { get; set; } = "";
 

--- a/CASCHost/CASCHost.csproj
+++ b/CASCHost/CASCHost.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <Platforms>AnyCPU;x64</Platforms>
+    <ApplicationIcon />
+    <OutputType>Exe</OutputType>
+    <StartupObject />
   </PropertyGroup>
 
   <ItemGroup>

--- a/CASCHost/DataWatcher.cs
+++ b/CASCHost/DataWatcher.cs
@@ -145,7 +145,7 @@ namespace CASCHost
 			CASContainer.Open(settings);
 			CASContainer.OpenCdnIndices(false);
 			CASContainer.OpenEncoding();
-			CASContainer.OpenRoot(settings.Locale, Startup.Settings.MinimumFileDataId);
+			CASContainer.OpenRoot(settings.Locale, Startup.Settings.MinimumFileDataId, Startup.Settings.OnlineListFile);
 
 			if(Startup.Settings.BNetAppSupport) // these are only needed by the bnet app launcher
 			{

--- a/CASCHost/appsettings.json
+++ b/CASCHost/appsettings.json
@@ -1,6 +1,7 @@
 {
   "AppSettings": {
     "MinimumFileDataId": 2500000,
+    "OnlineListFile": false,
     "BNetAppSupport": false,
     "StaticMode": false,
     "RebuildPassword": "",

--- a/CASCHost/appsettings.json
+++ b/CASCHost/appsettings.json
@@ -10,8 +10,8 @@
     "PatchUrl": "http://us.patch.battle.net:1119/wow",
     "Locale": "enus",
     "DirectoryHash": [
-      "b02eac153ad91adee3c24c9d80c114f9",
-      "68a88f97705094a9c5a3a6decf08b5ab"
+      "0aa8acdad03fa93a760d6a5824e1f0a3",
+      "89a7085aa643b8a200eef77c25d20439"
     ]
   }
 }


### PR DESCRIPTION
As the root format has changed since 8.2, **CASCHost** need some updates.

Fortunately, the client still parses the old root format, so the "necessary" update is just about reading correctly.
For files with no names, we need to generate a hash to allow changes on those existing files given the following structure: `{customDirectory}/{prefix}{filedata}`. Thus, you can replace files with just filedata quite easily.

This is not really a proper fix but it works ( both adding and replacing files ).